### PR TITLE
Adding SC2 macOS instructions

### DIFF
--- a/worlds/sc2wol/docs/setup_en.md
+++ b/worlds/sc2wol/docs/setup_en.md
@@ -16,6 +16,7 @@ to obtain a config file for StarCraft 2.
    - Linux users should also follow the instructions found at the bottom of this page 
      (["Running in Linux"](#running-in-linux)).
 2. Run ArchipelagoStarcraft2Client.exe.
+   - macOS users should instead follow the instructions found at (["Running in macOS"](#running-in-macos)) for this step only.
 3. Type the command `/download_data`. This will automatically install the Maps and Data files from the third link above.
 
 ## Where do I get a config file (aka "YAML") for this game?
@@ -34,6 +35,7 @@ Check out [Creating a YAML](https://archipelago.gg/tutorial/Archipelago/setup/en
 ## How do I join a MultiWorld game?
 
 1. Run ArchipelagoStarcraft2Client.exe.
+   - macOS users should instead follow the instructions found at (["Running in macOS"](#running-in-macos)) for this step only.
 2. Type `/connect [server ip]`.
 3. Type your slot name and the server's password when prompted.
 4. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see every mission. By default,
@@ -44,6 +46,10 @@ Check out [Creating a YAML](https://archipelago.gg/tutorial/Archipelago/setup/en
 First, check the log file for issues (stored at `[Archipelago Directory]/logs/SC2Client.txt`). If you can't figure out
 the log file, visit our [Discord's](https://discord.com/invite/8Z65BR2) tech-support channel for help. Please include a
 specific description of what's going wrong and attach your log file to your message.
+
+## Running in macOS
+
+To run StarCraft 2 through Archipelago in macOS, you will need to run the client via source as seen here: [macOS Guide](https://archipelago.gg/tutorial/Archipelago/mac/en). Note: when running the client, you will need to run the command `sudo python3 Starcraft2Client.py`. This is done to make sure that `/download_data` works correctly.
 
 ## Running in Linux
 


### PR DESCRIPTION
A few hours ago, I tested whether the client would run successfully on macOS (Send/Receive items, load maps, download maps, etc.). After the successful testing, I thought adding some documentation would be nice for those who want to play Archipelago on a macOS system.

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?


## How was this tested?


## If this makes graphical changes, please attach screenshots.
